### PR TITLE
Upgrade packages to minimize the size of dependency graph

### DIFF
--- a/YahooFinance.Core/YahooFinance.Core.Tests/YahooFinance.Core.Tests.csproj
+++ b/YahooFinance.Core/YahooFinance.Core.Tests/YahooFinance.Core.Tests.csproj
@@ -9,17 +9,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Divergic.Logging.Xunit" Version="3.3.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="NodaTime" Version="2.4.7" />
+    <PackageReference Include="Divergic.Logging.Xunit" Version="3.5.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.9" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0" />
+    <PackageReference Include="NodaTime" Version="2.4.8" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.analyzers" Version="0.10.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="1.2.1">
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Hi@Matthiee, I found an issue in the YahooFinance.Core.Tests.csproj:

Packages Divergic.Logging.Xunit v3.3.0, Microsoft.Extensions.Logging v3.1.3, Microsoft.NET.Test.Sdk v16.5.0, NodaTime v2.4.7, xunit.runner.visualstudio v2.4.1 and coverlet.collector v1.2.1 transitively introduce 85 dependencies into YahooFinance.Core’s dependency graph ([see dependency graph before upgrades](http://202.182.124.107:8000/YahooFinance-Core.html)), while Divergic.Logging.Xunit v3.5.1, Microsoft.Extensions.Logging v3.1.9, Microsoft.NET.Test.Sdk v16.7.0, NodaTime v2.4.8, xunit.runner.visualstudio v2.4.3 and coverlet.collector v1.3.0 can only introduce 58 dependencies ([see dependency graph after upgrades](http://202.182.124.107:8000/YahooFinance-Core_after.html)).

These upgrades can help project minimize the size of dependency graph.
Hope the PR can help you.

Best regards,
sucrose